### PR TITLE
feat: make daily rewards and game types sections collapsible

### DIFF
--- a/src/components/Game/Rooms.tsx
+++ b/src/components/Game/Rooms.tsx
@@ -8,6 +8,7 @@ import type { RoomCard, RoomData } from 'hooks/useGame'
 import { useAuth } from 'contexts/AuthContext'
 import { leaveGame } from 'services/gameService'
 import { hasRole } from 'utils/rolify'
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 
 const generateCards = (cards: RoomCard[]) => {
   return cards.map((c) => {
@@ -49,6 +50,7 @@ const RoomList = () => {
     anonymousGame: false,
     type: 3,
   })
+  const [isGameTypesInfoExpanded, setIsGameTypesInfoExpanded] = useState(true)
 
   const channel = new BroadcastChannel('site-channel')
 
@@ -438,13 +440,21 @@ const RoomList = () => {
 
       {/* Game Types Info */}
       <div className="bg-gradient-to-r from-black/60 to-blue-900/20 backdrop-blur-sm rounded-xl border border-blue-500/30 overflow-hidden mb-6">
-        <div className="bg-gradient-to-r from-blue-600/20 to-purple-600/20 px-4 py-3 border-b border-blue-500/30">
+        <div className="bg-gradient-to-r from-blue-600/20 to-purple-600/20 px-4 py-3 border-b border-blue-500/30 flex items-center justify-between">
           <h3 className="text-lg font-bold text-white">Types de parties</h3>
+          <button
+            onClick={() => setIsGameTypesInfoExpanded(!isGameTypesInfoExpanded)}
+            className="bg-transparent text-white hover:text-gray-300 p-1 rounded-md"
+          >
+            {isGameTypesInfoExpanded ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}
+          </button>
         </div>
 
-        <div className="p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <div className="bg-black/40 rounded-lg p-4 border border-blue-500/20">
-            <div className="flex items-center mb-2">
+        {isGameTypesInfoExpanded && (
+          <>
+            <div className="p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <div className="bg-black/40 rounded-lg p-4 border border-blue-500/20">
+                <div className="flex items-center mb-2">
               <div className="w-4 h-4 bg-blue-500 rounded-sm mr-2"></div>
               <h4 className="font-bold">
                 Partie <span className="text-blue-400">FUN</span>
@@ -522,6 +532,8 @@ const RoomList = () => {
             </p>
           </div>
         </div>
+          </>
+        )}
       </div>
 
       {!showForm && (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import 'styles/Room.scss'
 
-import React from 'react'
+import React, { useState } from 'react'
 import RoomList from 'components/Game/Rooms'
 import { useUser } from 'contexts/UserContext'
 import { staticStars, parallaxStars } from 'utils/animations'
@@ -9,10 +9,11 @@ import { motion } from 'framer-motion'
 import hero from 'assets/img/hero.png'
 import { Img as Image } from 'react-image'
 import DailyRewardsStatus from 'components/DailyRewardStatus'
-import { Calendar } from 'lucide-react'
+import { Calendar, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 
 const HomePage = () => {
   const { user } = useUser()
+  const [isDailyRewardsExpanded, setIsDailyRewardsExpanded] = useState(true)
   return (
     <>
       <div
@@ -157,15 +158,26 @@ const HomePage = () => {
             animate={ { opacity: 1, y: 0 } }
             transition={ { duration: 0.8, delay: 0.4 } }
           >
-            <div className="flex items-center mb-8">
-              <Calendar className="h-5 w-5 mr-2 text-indigo-400" />
-              <h2 className="text-2xl md:text-3xl font-bold">
-                Connexions Journalières</h2>
+            <div className="flex items-center justify-between mb-8">
+              <div className="flex items-center">
+                <Calendar className="h-5 w-5 mr-2 text-indigo-400" />
+                <h2 className="text-2xl md:text-3xl font-bold">
+                  Connexions Journalières
+                </h2>
+              </div>
+              <button
+                onClick={() => setIsDailyRewardsExpanded(!isDailyRewardsExpanded)}
+                className="bg-transparent text-white hover:text-gray-300 p-1 rounded-md"
+              >
+                {isDailyRewardsExpanded ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}
+              </button>
             </div>
 
-            <div>
-              <DailyRewardsStatus />
-            </div>
+            {isDailyRewardsExpanded && (
+              <div>
+                <DailyRewardsStatus />
+              </div>
+            )}
           </motion.div>
         </section>
 


### PR DESCRIPTION
Made the "Connexions Journalières" section in HomePage.tsx and the "Types de parties" section in Rooms.tsx collapsible.

- Added state variables to control the expanded/collapsed state of these sections.
- Implemented toggle buttons with chevron icons to change the visibility.
- Ensured that the sections are expanded by default and their states are independent.

You have tested and confirmed the functionality.