### PR TITLE
Fix: Improve server offline detection for guest users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,10 @@ const AppContent: React.FC = () => {
 
   const isInitializing = maintenanceLoading || userLoading
 
+  if (serverError) {
+    return <ServiceUnavailable />;
+  }
+
   if (isInitializing) {
     return <LoadingScreen />
   }
@@ -97,15 +101,10 @@ const AppContent: React.FC = () => {
         </>
       )}
       <Routes>
-        {serverError ? (
-          <>
-            <Route path="*" element={<ServiceUnavailable />} />
-          </>
-        ) : (
-          <>
-            {token ? (
-              <>
-                { user && (
+        <>
+          {token ? (
+            <>
+              { user && (
                   <>
                     <Route path="/" element={<HomePage />} />
                     <Route path="/account/settings" element={<UserSettingsPage />} />

--- a/src/contexts/MaintenanceContext.tsx
+++ b/src/contexts/MaintenanceContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, ReactNode, useContext, useState, useEffect } from 'react'
 import axios from 'axios'
+import { useError } from '../contexts/ErrorContext'
 
 interface MaintenanceContextType {
   serverMaintenance: boolean;
@@ -15,6 +16,7 @@ export const MaintenanceProvider: React.FC<{ children: ReactNode }> = ({ childre
   const [serverMaintenance, setServerMaintenance] = useState(false)
   const [maintenanceMessage, setMaintenanceMessage] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const { setServerError } = useError()
 
   useEffect(() => {
     axios.get('/api/server/maintenance')
@@ -27,8 +29,9 @@ export const MaintenanceProvider: React.FC<{ children: ReactNode }> = ({ childre
       })
       .catch(error => {
         console.error('Erreur lors de la vérification de la maintenance du serveur :', error)
+        setServerError(error)
       }).finally(() => setLoading(false))
-  }, [])
+  }, [setServerError])
 
   return (
     <MaintenanceContext.Provider value={{ serverMaintenance, setServerMaintenance, maintenanceMessage, setMaintenanceMessage, loading }}>


### PR DESCRIPTION
Previously, server offline status (resulting in a 503 error page) was primarily detected through API calls made within the UserContext, which only fully initializes for logged-in users. This meant that guest users would not reliably see the 503 page if the server was down.

This commit addresses the issue by:

1. Modifying `MaintenanceContext.tsx`: The initial call to `/api/server/maintenance` now also uses `setServerError` from `ErrorContext` if the request itself fails (e.g., network error, server returning 50x). This ensures that a server outage is detected early, even for guest users.
2. Updating `App.tsx`: The logic in `AppContent` has been adjusted to prioritize rendering the `ServiceUnavailable` component if `serverError` is true. This check now happens before the initialization checks (`isInitializing`) and the specific maintenance mode check (`serverMaintenance`).

These changes ensure that both guest and authenticated users are correctly shown the `ServiceUnavailable` page when the server is unreachable. The maintenance mode functionality remains unchanged for scenarios where the server is up but explicitly set to maintenance.