### PR TITLE
Integrate Galactic Jester (Card 14) voting ability

### DIFF
--- a/src/components/Game/PhaseAction.tsx
+++ b/src/components/Game/PhaseAction.tsx
@@ -44,6 +44,20 @@ const PhaseAction: React.FC<PhaseActionProps> = ({ player, roomId, isInn, gameTy
   const [hint, setHint] = useState<string | null>(null)
   const [selectHeight, setSelectHeight] = useState(0)
 
+  // Add this check for Galactic Jester
+  if (player.card?.id === 14 && player.canVote === false) {
+    return (
+      <motion.div
+        className="bg-black/40 backdrop-blur-sm rounded-lg border border-yellow-500/30 p-4 mt-4 text-center"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <h3 className="text-lg font-bold text-yellow-300">Vous avez perdu votre pouvoir de vote.</h3>
+      </motion.div>
+    )
+  }
+
   useEffect(() => {
     if (actionRequest && actionRequest.eligibleTargets.length > 0 && actionRequest.action.targetCount === 1) {
       const firstTargetId = actionRequest.eligibleTargets[0].id

--- a/src/components/Game/PlayersList.tsx
+++ b/src/components/Game/PlayersList.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from 'react-tooltip'
 import { faUserAstronaut } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart'
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan'
 import axios from 'axios'
 import { createPortal } from 'react-dom'
 import { useUser } from 'contexts/UserContext'
@@ -27,6 +28,7 @@ interface Player {
   isInfected: boolean
   customVote?: number
   id?: string | number
+  canVote?: boolean
 }
 
 interface PlayersListProps {
@@ -343,6 +345,13 @@ const PlayersList: React.FC<PlayersListProps> = ({
                   <span className="player sound-tick" data-profile={user?.isAdmin ? _player.realNickname || _player.nickname : _player.nickname}>
                     {_player.nickname}
                   </span>
+
+                  {/* Visual indicator for Galactic Jester without voting rights */}
+                  {_player.cardId === 14 && _player.canVote === false && (
+                    <span className="ml-1 text-yellow-400" title="Ne peut plus voter">
+                      <FontAwesomeIcon icon={faBan} />
+                    </span>
+                  )}
 
                   {/* Badges de statut */}
                   <div className="inline-flex gap-1 ml-1">

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -39,6 +39,7 @@ export interface PlayerType {
   isBrother: boolean
   isCharmed: boolean
   isInfected: boolean
+  canVote?: boolean
 }
 
 export interface Viewer {

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -44,6 +44,7 @@ export interface User {
   },
   registerIp?: string;
   lastLoginIp?: string;
+  canVote?: boolean;
 }
 
 export interface UserProfile extends User {


### PR DESCRIPTION
This commit implements the Galactic Jester's special voting mechanic:

- Adds a `canVote` boolean property to `PlayerType`, `Player`, and `User` interfaces.
- If the Galactic Jester is eliminated during a day vote, they lose their right to vote (`canVote` becomes false) but remain in the game.
- When `canVote` is false for the Galactic Jester:
    - The `PhaseAction` component displays "Vous avez perdu votre pouvoir de vote." instead of voting options.
    - The `PlayersList` component shows a visual indicator (ban icon) next to the Jester's name.

These changes primarily affect client-side display and UI interactions. The server-side logic for preventing the Jester's death and updating `canVote` is assumed to be handled separately.