### PR TITLE
Fix target selection reset for phase actions

### DIFF
--- a/src/components/Game/PhaseAction.tsx
+++ b/src/components/Game/PhaseAction.tsx
@@ -59,12 +59,23 @@ const PhaseAction: React.FC<PhaseActionProps> = ({ player, roomId, isInn, gameTy
   }
 
   useEffect(() => {
-    if (actionRequest && actionRequest.eligibleTargets.length > 0 && actionRequest.action.targetCount === 1) {
+    // Réinitialise toujours la sélection lorsqu'une nouvelle action débute
+    setSelectedTargets([])
+    setSelectedNickname(null)
+    setSelectedNicknames([])
+
+    if (
+      actionRequest &&
+      actionRequest.eligibleTargets.length > 0 &&
+      actionRequest.action.targetCount === 1
+    ) {
       const firstTargetId = actionRequest.eligibleTargets[0].id
       setSelectedTargets([firstTargetId])
 
       // Mettre à jour également le nickname sélectionné
-      const selectedTarget = actionRequest.eligibleTargets.find((target) => target.id === firstTargetId)
+      const selectedTarget = actionRequest.eligibleTargets.find(
+        (target) => target.id === firstTargetId,
+      )
       if (selectedTarget) {
         setSelectedNickname(selectedTarget.nickname)
       }


### PR DESCRIPTION
## Summary
- reset target selection state when a new phase action starts

## Testing
- `npm test --silent` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f5b45e0c8323b6c1c2a8251b337c