### PR TITLE
Fix Rooms refresh after finishing game

### DIFF
--- a/src/components/Game/GamePageContent.tsx
+++ b/src/components/Game/GamePageContent.tsx
@@ -649,7 +649,8 @@ const GamePage = () => {
   }, [audioVolume])
 
   if (gameError) {
-    localStorage.setItem('gameFinished', 'true')
+    // Using a unique value ensures the storage event always triggers
+    localStorage.setItem('gameFinished', Date.now().toString())
 
     const isLeaveMessage = gameError.includes('Vous avez bien quitté la partie.')
     return (


### PR DESCRIPTION
## Summary
- ensure localStorage updates always trigger `storage` events

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fb2c36708323ae1e416cc79bff16