### PR TITLE
Add moderation action modals

### DIFF
--- a/src/components/Moderation/Actions.tsx
+++ b/src/components/Moderation/Actions.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Button } from 'components/UI/Button'
+import { useUser } from 'contexts/UserContext'
+import WarnModal from './WarnModal'
+import BanModal from './BanModal'
+import HistoryModal from './HistoryModal'
+import NoteModal from './NoteModal'
+import DoublesModal from './DoublesModal'
+import RenameModal from './RenameModal'
+import RemoveSignatureModal from './RemoveSignatureModal'
+import RemoveAvatarModal from './RemoveAvatarModal'
+import IpModal from './IpModal'
+import { usePermissions } from 'hooks/usePermissions'
+
+interface ModerationActionsProps {
+  targetUser: {
+    id: number
+    nickname: string
+    avatar?: string
+    sanctionHistory?: {
+      type: string
+      count: number
+    }[]
+  }
+  compact?: boolean
+}
+
+const ModerationActions: React.FC<ModerationActionsProps> = ({ targetUser, compact = false }) => {
+  const { user } = useUser()
+  const { checkPermission } = usePermissions()
+  const [isWarnModalOpen, setIsWarnModalOpen] = useState(false)
+  const [isBanModalOpen, setIsBanModalOpen] = useState(false)
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false)
+  const [isNoteOpen, setIsNoteOpen] = useState(false)
+  const [isDoublesOpen, setIsDoublesOpen] = useState(false)
+  const [isRenameOpen, setIsRenameOpen] = useState(false)
+  const [isRemoveSignatureOpen, setIsRemoveSignatureOpen] = useState(false)
+  const [isRemoveAvatarOpen, setIsRemoveAvatarOpen] = useState(false)
+  const [isIpOpen, setIsIpOpen] = useState(false)
+  const [actionIsShown, setActionIsShown] = useState(false)
+
+  const permissions = {
+    antecedents: checkPermission('site', 'antecedents'),
+    moderationNotes: checkPermission('site', 'moderationNotes'),
+    warn: checkPermission('site', 'warn'),
+    stalk: checkPermission('site', 'stalk'),
+    dcInfos: checkPermission('site', 'addPoints'),
+    rename: checkPermission('site', 'rename'),
+    removeSignature: checkPermission('site', 'removeSignature'),
+    addPoints: checkPermission('site', 'addPoints'),
+    ip: checkPermission('site', 'ip'),
+    ban: checkPermission('site', 'ban'),
+  }
+
+  const isModerator = user?.roleId && [1, 2, 4, 5].includes(user.roleId)
+  if (!isModerator) return null
+
+  // Le container principal : un seul flex pour TOUTES les actions
+  return (
+    <>
+      {!actionIsShown && (
+        <div className={`actions flex flex-wrap items-center ${compact ? 'gap-1' : 'gap-2'}`}>
+          {permissions.antecedents && (
+            <a
+              role="button"
+              onClick={() => setIsHistoryOpen(true)}
+              className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}
+            >
+              Antécédents
+            </a>
+          )}
+          {permissions.moderationNotes && (
+            <a
+              role="button"
+              onClick={() => setIsNoteOpen(true)}
+              className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}
+            >
+              Notes sur le joueur
+            </a>
+          )}
+          {permissions.warn && (
+            <Button
+              onClick={() => setIsWarnModalOpen(true)}
+              className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'}
+                bg-gradient-to-r from-yellow-600 to-amber-600
+                hover:from-yellow-700 hover:to-amber-700
+                text-white rounded-lg transition-all`}
+            >
+              {compact ? (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              ) : (
+                'Avertir'
+              )}
+            </Button>
+          )}
+          {permissions.stalk && (
+            <a role="button" className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Surveiller
+            </a>
+          )}
+          {permissions.dcInfos && (
+            <a role="button" onClick={() => setIsDoublesOpen(true)} className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Doubles-Comptes
+            </a>
+          )}
+          {permissions.rename && (
+            <a role="button" onClick={() => setIsRenameOpen(true)} className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Renommer
+            </a>
+          )}
+          {permissions.removeSignature && (
+            <a role="button" onClick={() => setIsRemoveSignatureOpen(true)} className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Supprimer la signature
+            </a>
+          )}
+          {permissions.addPoints && (
+            <a role="button" className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Ajouter des points
+            </a>
+          )}
+          {permissions.ip && (
+            <a role="button" onClick={() => setIsIpOpen(true)} className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'} button_secondary bgred`}>
+              Voir l’IP
+            </a>
+          )}
+          {permissions.ban && (
+            <Button
+              onClick={() => setIsBanModalOpen(true)}
+              className={`${compact ? 'px-2 py-1 text-xs' : 'px-3 py-2'}
+                bg-gradient-to-r from-red-600 to-red-800
+                hover:from-red-700 hover:to-red-900
+                text-white rounded-lg transition-all`}
+            >
+              {compact ? (
+                /* icône */
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M5.5 4.21 4.21 5.5 8.72 10H6v2h6V6h-2v2.72L5.5 4.21zM18 18H6v-5h-.81l2 2H8v2h8v-1.19l2 2V18z"/></svg>
+              ) : (
+                'Bannir'
+              )}
+            </Button>
+          )}
+        </div>
+      )}
+
+      <WarnModal isOpen={isWarnModalOpen} onClose={() => setIsWarnModalOpen(false)} targetUser={targetUser} />
+      <BanModal isOpen={isBanModalOpen} onClose={() => setIsBanModalOpen(false)} targetUser={targetUser} />
+      <HistoryModal isOpen={isHistoryOpen} onClose={() => setIsHistoryOpen(false)} userId={targetUser.id} />
+      <NoteModal isOpen={isNoteOpen} onClose={() => setIsNoteOpen(false)} userId={targetUser.id} />
+      <DoublesModal isOpen={isDoublesOpen} onClose={() => setIsDoublesOpen(false)} userId={targetUser.id} />
+      <RenameModal isOpen={isRenameOpen} onClose={() => setIsRenameOpen(false)} userId={targetUser.id} />
+      <RemoveSignatureModal isOpen={isRemoveSignatureOpen} onClose={() => setIsRemoveSignatureOpen(false)} userId={targetUser.id} />
+      <RemoveAvatarModal isOpen={isRemoveAvatarOpen} onClose={() => setIsRemoveAvatarOpen(false)} userId={targetUser.id} />
+      <IpModal isOpen={isIpOpen} onClose={() => setIsIpOpen(false)} userId={targetUser.id} />
+    </>
+  )
+}
+
+export default ModerationActions

--- a/src/components/Moderation/BanModal.tsx
+++ b/src/components/Moderation/BanModal.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import React, { useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+import { Input } from 'components/UI/Input'
+import { Textarea } from 'components/UI/Textarea'
+import { Label } from 'components/UI/Label'
+
+interface BanModalProps {
+  isOpen: boolean
+  onClose: () => void
+  targetUser: {
+    id: number
+    nickname: string
+  }
+}
+
+const BanModal: React.FC<BanModalProps> = ({ isOpen, onClose, targetUser }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [reason, setReason] = useState('')
+  const [duration, setDuration] = useState(24)
+  const [comment, setComment] = useState('')
+
+  const handleBan = async () => {
+    await axios.post('/api/moderation/ban', {
+      userId: targetUser.id,
+      reason,
+      duration,
+      comment,
+    }, authHeaders).catch(() => {})
+    onClose()
+    setReason('')
+    setComment('')
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[425px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Bannir {targetUser.nickname}</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="banReason" className="text-right">Raison</Label>
+            <Input id="banReason" value={reason} onChange={(e) => setReason(e.target.value)} className="col-span-3" />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="banDuration" className="text-right">Durée (heures)</Label>
+            <Input id="banDuration" type="number" value={duration} onChange={(e) => setDuration(Number.parseInt(e.target.value))} className="col-span-3" />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="banComment" className="text-right">Commentaire</Label>
+            <Textarea id="banComment" value={comment} onChange={(e) => setComment(e.target.value)} className="col-span-3" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="destructive" onClick={handleBan}>Bannir</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default BanModal

--- a/src/components/Moderation/DoublesModal.tsx
+++ b/src/components/Moderation/DoublesModal.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+
+interface DoublesModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+interface DoubleUser { id: number; nickname: string }
+
+const DoublesModal: React.FC<DoublesModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [doubles, setDoubles] = useState<DoubleUser[]>([])
+
+  useEffect(() => {
+    if (isOpen) {
+      axios.get(`/api/moderation/doubles/${userId}`, authHeaders).then(res => setDoubles(res.data)).catch(() => {})
+    }
+  }, [isOpen, userId])
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[400px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Doubles comptes</DialogTitle>
+          <DialogDescription className="text-gray-400">Joueurs partageant la même IP.</DialogDescription>
+        </DialogHeader>
+        <ul className="list-disc ml-5 space-y-1 text-sm max-h-[50vh] overflow-auto">
+          {doubles.map((d) => (
+            <li key={d.id}>{d.nickname}</li>
+          ))}
+        </ul>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Fermer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default DoublesModal

--- a/src/components/Moderation/HistoryModal.tsx
+++ b/src/components/Moderation/HistoryModal.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+
+interface HistoryModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+interface HistoryData {
+  warnings: { reason: string }[]
+  bans: { reason: string }[]
+  nickChanges: { oldNickname: string; newNickname: string }[]
+}
+
+const HistoryModal: React.FC<HistoryModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [history, setHistory] = useState<HistoryData>({ warnings: [], bans: [], nickChanges: [] })
+
+  useEffect(() => {
+    if (isOpen) {
+      axios.get(`/api/moderation/history/${userId}`, authHeaders).then(res => setHistory(res.data)).catch(() => {})
+    }
+  }, [isOpen, userId])
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[500px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Antécédents</DialogTitle>
+          <DialogDescription className="text-gray-400">Avertissements, bannissements et changements de pseudo.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[60vh] overflow-auto">
+          <div>
+            <h4 className="font-medium mb-2">Avertissements</h4>
+            <ul className="list-disc ml-5 space-y-1 text-sm">
+              {history.warnings.map((w, i) => (
+                <li key={i}>{w.reason}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="font-medium mb-2">Bannissements</h4>
+            <ul className="list-disc ml-5 space-y-1 text-sm">
+              {history.bans.map((b, i) => (
+                <li key={i}>{b.reason}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="font-medium mb-2">Changements de pseudo</h4>
+            <ul className="list-disc ml-5 space-y-1 text-sm">
+              {history.nickChanges.map((n, i) => (
+                <li key={i}>{n.oldNickname} → {n.newNickname}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Fermer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default HistoryModal

--- a/src/components/Moderation/IpModal.tsx
+++ b/src/components/Moderation/IpModal.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+
+interface IpModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+interface Ips { registerIp: string; lastLoginIp: string }
+
+const IpModal: React.FC<IpModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [ips, setIps] = useState<Ips | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      axios.get(`/api/moderation/ips/${userId}`, authHeaders).then(res => setIps(res.data)).catch(() => {})
+    }
+  }, [isOpen, userId])
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[400px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Adresses IP</DialogTitle>
+        </DialogHeader>
+        {ips && (
+          <div className="space-y-2 text-sm">
+            <p>IP d'inscription : <span className="font-medium">{ips.registerIp}</span></p>
+            <p>Dernière IP : <span className="font-medium">{ips.lastLoginIp}</span></p>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Fermer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default IpModal

--- a/src/components/Moderation/NoteModal.tsx
+++ b/src/components/Moderation/NoteModal.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+import { Textarea } from 'components/UI/Textarea'
+
+interface NoteModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [note, setNote] = useState('')
+
+  useEffect(() => {
+    if (isOpen) {
+      axios.get(`/api/moderation/note/${userId}`, authHeaders).then(res => setNote(res.data?.note || '')).catch(() => {})
+    }
+  }, [isOpen, userId])
+
+  const save = async () => {
+    await axios.post(`/api/moderation/note/${userId}`, { note }, authHeaders).catch(() => {})
+    onClose()
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[425px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Note de modération</DialogTitle>
+          <DialogDescription className="text-gray-400">Ajouter ou modifier une note concernant ce joueur.</DialogDescription>
+        </DialogHeader>
+        <Textarea value={note} onChange={(e) => setNote(e.target.value)} />
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="default" onClick={save}>Enregistrer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default NoteModal

--- a/src/components/Moderation/RemoveAvatarModal.tsx
+++ b/src/components/Moderation/RemoveAvatarModal.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import React from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+
+interface RemoveAvatarModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+const RemoveAvatarModal: React.FC<RemoveAvatarModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+
+  const handleRemove = async () => {
+    await axios.post('/api/moderation/remove-avatar', { userId }, authHeaders).catch(() => {})
+    onClose()
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[400px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Supprimer l'avatar ?</DialogTitle>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="destructive" onClick={handleRemove}>Confirmer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default RemoveAvatarModal

--- a/src/components/Moderation/RemoveSignatureModal.tsx
+++ b/src/components/Moderation/RemoveSignatureModal.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import React from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+
+interface RemoveSignatureModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+const RemoveSignatureModal: React.FC<RemoveSignatureModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+
+  const handleRemove = async () => {
+    await axios.post('/api/moderation/remove-signature', { userId }, authHeaders).catch(() => {})
+    onClose()
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[400px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Supprimer la signature ?</DialogTitle>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="destructive" onClick={handleRemove}>Confirmer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default RemoveSignatureModal

--- a/src/components/Moderation/RenameModal.tsx
+++ b/src/components/Moderation/RenameModal.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import React, { useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+import { Input } from 'components/UI/Input'
+import { Label } from 'components/UI/Label'
+
+interface RenameModalProps {
+  isOpen: boolean
+  onClose: () => void
+  userId: number
+}
+
+const RenameModal: React.FC<RenameModalProps> = ({ isOpen, onClose, userId }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [nickname, setNickname] = useState('')
+
+  const rename = async () => {
+    await axios.post('/api/moderation/rename', { userId, nickname }, authHeaders).catch(() => {})
+    onClose()
+    setNickname('')
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[425px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Renommer le joueur</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="nickname" className="text-right">Pseudo</Label>
+            <Input id="nickname" value={nickname} onChange={(e) => setNickname(e.target.value)} className="col-span-3" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="default" onClick={rename}>Valider</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default RenameModal

--- a/src/components/Moderation/WarnModal.tsx
+++ b/src/components/Moderation/WarnModal.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React, { useState } from 'react'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'components/UI/Dialog'
+import { Button } from 'components/UI/Button'
+import { Input } from 'components/UI/Input'
+
+interface WarnModalProps {
+  isOpen: boolean
+  onClose: () => void
+  targetUser: {
+    id: number
+    nickname: string
+  }
+}
+
+const WarnModal: React.FC<WarnModalProps> = ({ isOpen, onClose, targetUser }) => {
+  const { token } = useAuth()
+  const authHeaders = token ? { headers: { Authorization: `Bearer ${token}` } } : {}
+  const [reason, setReason] = useState('')
+
+  const handleWarn = async () => {
+    await axios.post('/api/moderation/warn', { userId: targetUser.id, reason }, authHeaders).catch(() => {})
+    onClose()
+    setReason('')
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[425px] bg-gray-900 text-white border-gray-800">
+        <DialogHeader>
+          <DialogTitle>Avertir {targetUser.nickname}</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <Input placeholder="Raison" value={reason} onChange={(e) => setReason(e.target.value)} />
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>Annuler</Button>
+          <Button variant="destructive" onClick={handleWarn}>Avertir</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default WarnModal


### PR DESCRIPTION
## Summary
- restore original `Actions` layout
- create dedicated modals for each moderation feature

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848463a5f1883239546b3b76d2aa488