### PR TITLE
Add discord vocal option

### DIFF
--- a/src/components/Game/Controls.tsx
+++ b/src/components/Game/Controls.tsx
@@ -12,6 +12,7 @@ import {
   updateRoomTimer,
   updateRoomCards,
   addFavoriteGame, leaveGame,
+  linkDiscordChannel,
 } from 'services/gameService'
 import { useAuth } from 'contexts/AuthContext'
 import { useUser } from 'contexts/UserContext'
@@ -93,6 +94,7 @@ const GameControls: React.FC<GameControlsProps> = ({
   const [favoriteComment, setFavoriteComment] = useState<string>('')
   const [replayGameId, setReplayGameId] = useState<number | null>(null)
   const [isSavingComment, setIsSavingComment] = useState<boolean>(false)
+  const [discordChannelInput, setDiscordChannelInput] = useState('')
 
   const openEditComposition = () => {
     if (!isCreator || isArchive || roomData.type === 3) return
@@ -432,6 +434,19 @@ const GameControls: React.FC<GameControlsProps> = ({
     socket.emit('bipNotReadyPlayers', gameId)
   }
 
+  const handleLinkChannel = async () => {
+    if (!gameId || !discordChannelInput || !token) return
+    try {
+      const data = await linkDiscordChannel(gameId, discordChannelInput, token)
+      if (data.discordChannelId) {
+        setRoomData((prev) => ({ ...prev, discordChannelId: data.discordChannelId }))
+        setDiscordChannelInput('')
+      }
+    } catch (error) {
+      console.error('Erreur lors du lien du salon Discord :', error)
+    }
+  }
+
   const cardId = player?.card?.id
   const memoizedCardImage = useMemo(() => <CardImage cardId={cardId} isArchive={isArchive} />, [cardId, isArchive])
 
@@ -727,6 +742,31 @@ const GameControls: React.FC<GameControlsProps> = ({
                   />
                 )}
               </div>
+
+              {/* Lier un salon vocal Discord */}
+              {roomData.discordChannelId ? (
+                <p className="text-center text-green-400">
+                  Salon vocal lié : {roomData.discordChannelId}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    type="text"
+                    value={discordChannelInput}
+                    onChange={(e) => setDiscordChannelInput(e.target.value)}
+                    placeholder="ID du salon vocal Discord"
+                    className="w-full p-2 bg-black/40 border border-blue-500/30 rounded-lg text-white"
+                  />
+                  <motion.button
+                    className="sound-tick w-full px-4 py-2 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-lg transition-all"
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    onClick={handleLinkChannel}
+                  >
+                    Lier le salon vocal
+                  </motion.button>
+                </div>
+              )}
 
               {/* Bouton de lancement */}
               <motion.button

--- a/src/components/Game/Create.tsx
+++ b/src/components/Game/Create.tsx
@@ -16,6 +16,7 @@ const CreateGame = () => {
     roles: ['voyageur', 'sableur', 'archiviste', 'synchronisateur'],
     anonymousVotes: false,
     privateGame: false,
+    discordChannelId: false,
     password: '',
     timer: 3,
   })
@@ -172,6 +173,19 @@ const CreateGame = () => {
                   />
                 }
                 label="Partie privée"
+              />
+            </Box>
+
+            <Box mb={2}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    name="discordChannelId"
+                    checked={formData.discordChannelId}
+                    onChange={handleChange}
+                  />
+                }
+                label="Partie vocale"
               />
             </Box>
 

--- a/src/components/Game/Rooms.tsx
+++ b/src/components/Game/Rooms.tsx
@@ -44,6 +44,7 @@ const RoomList = () => {
     maxPlayers: 6,
     anonymousVotes: false,
     privateGame: false,
+    discordChannelId: false,
     password: '',
     timer: 3,
     whiteFlag: false,
@@ -788,6 +789,12 @@ const RoomList = () => {
                     disabled={true}
                   >
                     Sélective
+                  </button>
+                  <button
+                    className={`px-4 py-2 rounded-lg transition-colors ${formData.discordChannelId ? 'bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg' : 'bg-black/40 border border-blue-500/30 text-blue-300'}`}
+                    onClick={() => setFormData((prev) => ({ ...prev, discordChannelId: !prev.discordChannelId }))}
+                  >
+                    Vocale
                   </button>
                   <button
                     className={`px-4 py-2 rounded-lg transition-colors ${formData.privateGame ? 'bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg' : 'bg-black/40 border border-blue-500/30 text-blue-300'}`}

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -71,6 +71,7 @@ export interface RoomData {
   maxPlayers: number
   isPrivate: boolean
   password?: string
+  discordChannelId?: string | null
   phase: number
   whiteFlag: boolean
   anonymousGame: boolean
@@ -103,6 +104,7 @@ export const useGame = (
     type: 0,
     maxPlayers: 6,
     isPrivate: true,
+    discordChannelId: null,
     cards: [],
     phase: 0,
     whiteFlag: false,

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -173,3 +173,19 @@ export const addFavoriteGame = async (gameId: string, action: 'add' | 'delete', 
   return response.data
 }
 
+/**
+ * Lie un salon vocal Discord à la partie
+ */
+export const linkDiscordChannel = async (
+  gameId: string,
+  channelId: string,
+  token: string | null,
+) => {
+  const response = await axios.post(
+    `/api/games/room/${gameId}/discord-channel`,
+    { channelId },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}
+

--- a/src/types/room.d.ts
+++ b/src/types/room.d.ts
@@ -35,6 +35,7 @@ export interface RoomAttributes {
   maxPlayers: number
   anonymousVotes: boolean
   privateGame: boolean
+  discordChannelId?: string | null
   password: string | null
   status: 'waiting' | 'in_progress' | 'completed'
   phase: number


### PR DESCRIPTION
## Summary
- allow users to flag games as vocal when creating
- allow linking a discord voice channel to a game
- expose new API helper
- keep room types up to date with discord info

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684b429d5e708323b7e418f45eb68b67