### PR TITLE
Add premium gating and payment integration

### DIFF
--- a/src/components/Game/Create.tsx
+++ b/src/components/Game/Create.tsx
@@ -7,6 +7,8 @@ import { useAuth } from 'contexts/AuthContext'
 const CreateGame = () => {
   const { token } = useAuth()
   const { user } = useUser()
+  const premiumDate = user?.premium ? new Date(user.premium) : null
+  const isPremium = premiumDate ? new Date().getTime() < premiumDate.getTime() : false
   const [inGame, setInGame] = useState(false)
   const [showForm, setShowForm] = useState(false)
   const [gameId, setGameId] = useState<number | null>(null)
@@ -157,10 +159,16 @@ const CreateGame = () => {
                     name="anonymousVotes"
                     checked={formData.anonymousVotes}
                     onChange={handleChange}
+                    disabled={!isPremium}
                   />
                 }
                 label="Votes anonymes"
               />
+              {!isPremium && (
+                <Typography variant="caption" color="text.secondary">
+                  Réservé aux Premium
+                </Typography>
+              )}
             </Box>
 
             <Box mb={2}>
@@ -170,10 +178,16 @@ const CreateGame = () => {
                     name="privateGame"
                     checked={formData.privateGame}
                     onChange={handleChange}
+                    disabled={!isPremium}
                   />
                 }
                 label="Partie privée"
               />
+              {!isPremium && (
+                <Typography variant="caption" color="text.secondary">
+                  Réservé aux Premium
+                </Typography>
+              )}
             </Box>
 
             <Box mb={2}>
@@ -189,7 +203,7 @@ const CreateGame = () => {
               />
             </Box>
 
-            {formData.privateGame && (
+            {isPremium && formData.privateGame && (
               <Box mb={2}>
                 <TextField
                   fullWidth

--- a/src/components/Shop/Credits.tsx
+++ b/src/components/Shop/Credits.tsx
@@ -6,6 +6,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from 'components/UI/Tabs'
 import { Badge } from 'components/UI/Badge'
 import { Button } from 'components/UI/Button'
 import { Card } from 'components/UI/Card'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from 'components/UI/DropdownMenu'
 import { Input } from 'components/UI/Input'
 import { CreditPack, PremiumPlan, Transaction } from 'types/shop'
 import axios from 'axios'
@@ -162,6 +168,34 @@ const PremiumCredits : React.FC = () => {
   const [giftType, setGiftType] = useState('credits')
   const [giftAmount, setGiftAmount] = useState('500')
   const [giftRecipient, setGiftRecipient] = useState('')
+
+  const handleBuyPremium = async (planId: number, provider: 'stripe' | 'paypal') => {
+    if (!token) return
+    try {
+      const { data } = await axios.post(
+        '/api/payments/premium',
+        { planId, provider },
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      if (data.url) window.location.href = data.url
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  const handleBuyCredits = async (packId: number, provider: 'stripe' | 'paypal') => {
+    if (!token) return
+    try {
+      const { data } = await axios.post(
+        '/api/payments/credits',
+        { packId, provider },
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      if (data.url) window.location.href = data.url
+    } catch (e) {
+      console.log(e)
+    }
+  }
 
   useEffect(() => {
     async function retrieveShopOffers() {
@@ -347,11 +381,19 @@ const PremiumCredits : React.FC = () => {
                         Cosmétiques exclusifs mensuels
                       </li>
                     </ul>
-                    <Button
-                      className={ `w-full ${ plan.popular ? 'bg-purple-600 hover:bg-purple-700': 'bg-indigo-600 hover:bg-indigo-700' }` }
-                    >
-                      Acheter
-                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          className={ `w-full ${ plan.popular ? 'bg-purple-600 hover:bg-purple-700': 'bg-indigo-600 hover:bg-indigo-700' }` }
+                        >
+                          Acheter
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => handleBuyPremium(plan.id, 'stripe')}>Stripe</DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleBuyPremium(plan.id, 'paypal')}>PayPal</DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 </Card>
               )) }
@@ -419,11 +461,19 @@ const PremiumCredits : React.FC = () => {
                   <div className="text-2xl font-bold mb-6">{ pack.price }€
                   </div>
 
-                  <Button
-                    className={ `w-full ${ pack.popular ? 'bg-indigo-600 hover:bg-indigo-700': 'bg-gray-700 hover:bg-gray-600' }` }
-                  >
-                    Acheter
-                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        className={ `w-full ${ pack.popular ? 'bg-indigo-600 hover:bg-indigo-700': 'bg-gray-700 hover:bg-gray-600' }` }
+                      >
+                        Acheter
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => handleBuyCredits(pack.id, 'stripe')}>Stripe</DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => handleBuyCredits(pack.id, 'paypal')}>PayPal</DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </Card>
             )) }


### PR DESCRIPTION
## Summary
- restrict anonymous/private options to premium players
- allow purchase of premium plans and credits via Stripe or PayPal

## Testing
- `npm test --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686949b35f14832393770d777b6eb413