### PR TITLE
Add throwable items for premium players

### DIFF
--- a/src/components/Game/GamePageContent.tsx
+++ b/src/components/Game/GamePageContent.tsx
@@ -27,6 +27,7 @@ import { parallaxStars, staticStars } from 'utils/animations'
 import GuideRequestModal from './GuideRequestModal'
 import GuideChat from './GuideChat'
 import BugReportModal from './BugReportModal'
+import ThrownItem from './ThrownItem'
 import axios from 'axios'
 import { toast } from 'react-toastify'
 import { ToastDefaultOptions } from 'utils/toastOptions'
@@ -78,6 +79,11 @@ const GamePage = () => {
 
   const [highlightedPlayers, setHighlightedPlayers] = useState<{ [nickname: string]: string }>({})
   const [showBugReportModal, setShowBugReportModal] = useState(false)
+  const [thrownItems, setThrownItems] = useState<{ id: string; image: string }[]>([])
+
+  const removeThrownItem = (id: string) => {
+    setThrownItems(prev => prev.filter(item => item.id !== id))
+  }
 
   // États pour la gestion de la connexion
   const wasDisconnectedRef = useRef(false)
@@ -388,11 +394,18 @@ const GamePage = () => {
       }
     })
 
+    const handleItemThrown = (data: { item: string }) => {
+      setThrownItems(prev => [...prev, { id: `${Date.now()}-${Math.random()}`, image: data.item }])
+    }
+
+    socket.on('itemThrown', handleItemThrown)
+
     return () => {
       socket.offAny()
       socket.off('bipNotReadyPlayers')
       socket.off('music')
       socket.off('stopMusic')
+      socket.off('itemThrown', handleItemThrown)
     }
   }, [socket, player])
 
@@ -1351,6 +1364,10 @@ const GamePage = () => {
           username={player?.nickname || viewer?.user?.nickname || 'Anonyme'}
         />
       )}
+
+      {thrownItems.map((ti) => (
+        <ThrownItem key={ti.id} src={ti.image} onComplete={() => removeThrownItem(ti.id)} />
+      ))}
     </>
   )
 }

--- a/src/components/Game/PlayersList.tsx
+++ b/src/components/Game/PlayersList.tsx
@@ -105,26 +105,29 @@ const PlayersList: React.FC<PlayersListProps> = ({
   const [contextMenu, setContextMenu] = useState<{
     isOpen: boolean
     playerName: string
+    playerId: number
     position: { x: number; y: number }
   }>({
     isOpen: false,
     playerName: '',
+    playerId: 0,
     position: { x: 0, y: 0 },
   })
 
-  const handleRightClick = (e: React.MouseEvent, playerName: string) => {
+  const handleRightClick = (e: React.MouseEvent, target: Player) => {
     e.preventDefault()
     e.stopPropagation()
 
     setContextMenu({
       isOpen: true,
-      playerName,
+      playerName: target.nickname,
+      playerId: target.playerId,
       position: { x: e.clientX, y: e.clientY },
     })
   }
 
   const closeContextMenu = () => {
-    setContextMenu({ isOpen: false, playerName: '', position: { x: 0, y: 0 } })
+    setContextMenu({ isOpen: false, playerName: '', playerId: 0, position: { x: 0, y: 0 } })
   }
 
   const handleKickClick = (nickname: string) => {
@@ -304,7 +307,7 @@ const PlayersList: React.FC<PlayersListProps> = ({
                 key={index}
                 className={`flex items-center p-2 rounded-lg ${!_player.alive ? 'bg-red-900/20 border border-red-500/20' : isHighlighted ? '' : 'hover:bg-black/30'} transition-colors relative group cursor-pointer`}
                 style={{ backgroundColor: isHighlighted || '' }}
-                onContextMenu={(e) => handleRightClick(e, _player.nickname)}
+                onContextMenu={(e) => handleRightClick(e, _player)}
                 title={isCurrentPlayer ? 'Vous' : `Clic droit pour les actions sur ${_player.nickname}`}
               >
                 {/* Indicateurs de rôle et statut */}
@@ -620,6 +623,7 @@ const PlayersList: React.FC<PlayersListProps> = ({
         isOpen={contextMenu.isOpen}
         onClose={closeContextMenu}
         playerName={contextMenu.playerName}
+        playerId={contextMenu.playerId}
         position={contextMenu.position}
         socket={socket}
         gameId={gameId}

--- a/src/components/Game/ThrowItemModal.tsx
+++ b/src/components/Game/ThrowItemModal.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import axios from 'axios'
+import { useAuth } from 'contexts/AuthContext'
+import type { Item, UserInventory } from 'types/shop'
+
+interface ThrowItemModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSelect: (itemId: number) => void
+}
+
+const ThrowItemModal: React.FC<ThrowItemModalProps> = ({ isOpen, onClose, onSelect }) => {
+  const { token } = useAuth()
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const fetchData = async () => {
+      setLoading(true)
+      try {
+        const [shopRes, invRes] = await Promise.all([
+          axios.get('/api/shop'),
+          axios.get('/api/users/inventory', { headers: { Authorization: `Bearer ${token}` } }),
+        ])
+        const inventory: UserInventory[] = invRes.data.inventory || []
+        const owned = new Set(inventory.map(i => i.itemId))
+        const shopItems: Item[] = shopRes.data.items
+        setItems(shopItems.filter(i => i.categoryId === 4 && owned.has(i.id)))
+      } catch (e) {
+        console.error(e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [isOpen, token])
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <motion.div
+            className="bg-gradient-to-r from-black/90 to-gray-900/90 rounded-xl border border-gray-500/30 p-6 max-w-md w-full mx-4"
+            initial={{ scale: 0.9, y: 20, opacity: 0 }}
+            animate={{ scale: 1, y: 0, opacity: 1 }}
+            exit={{ scale: 0.9, y: 20, opacity: 0 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-xl font-bold text-white mb-4">Choisir un objet</h2>
+            {loading ? (
+              <p className="text-white">Chargement...</p>
+            ) : (
+              <div className="grid grid-cols-3 gap-4">
+                {items.map(item => (
+                  <button
+                    key={item.id}
+                    onClick={() => onSelect(item.id)}
+                    className="flex flex-col items-center gap-1 hover:bg-white/10 p-2 rounded"
+                  >
+                    <img src={item.image} alt={item.name} className="w-16 h-16 object-contain" />
+                    <span className="text-white text-xs text-center">{item.name}</span>
+                  </button>
+                ))}
+                {items.length === 0 && <p className="text-white">Aucun objet disponible</p>}
+              </div>
+            )}
+            <div className="mt-4 text-right">
+              <button onClick={onClose} className="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded">Fermer</button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default ThrowItemModal

--- a/src/components/Game/ThrownItem.tsx
+++ b/src/components/Game/ThrownItem.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import React from 'react'
+import { motion } from 'framer-motion'
+
+interface ThrownItemProps {
+  src: string
+  onComplete: () => void
+}
+
+const ThrownItem: React.FC<ThrownItemProps> = ({ src, onComplete }) => {
+  const left = Math.random() * 80 + 10
+  return (
+    <motion.img
+      src={src}
+      className="fixed z-50 pointer-events-none w-20 h-20"
+      style={{ left: `${left}vw` }}
+      initial={{ top: '-20vh', scale: 0.8, rotate: 0 }}
+      animate={{ top: '40vh', scale: 1.2, rotate: 720 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 1, ease: 'easeOut' }}
+      onAnimationComplete={onComplete}
+    />
+  )
+}
+
+export default ThrownItem


### PR DESCRIPTION
## Summary
- add ThrowItemModal and ThrownItem animation component
- support item throwing via PlayerContextMenu
- handle `itemThrown` socket event and display animation

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8bd7b1008323b94dd4db2e44bb56