### PR TITLE
Implement avatar creation reminder

### DIFF
--- a/src/components/Auth/Settings/index.tsx
+++ b/src/components/Auth/Settings/index.tsx
@@ -19,15 +19,22 @@ import ModHistory from './ModHistory'
 import Discord from './Discord'
 import Referral from './Referral'
 import AvatarPage from 'pages/AvatarCreator'
+import AvatarIntroPopup from 'components/Avatar/AvatarIntroPopup'
 
 const UserSettings : React.FC = () => {
   const { user } = useUser()
   const [activeTab, setActiveTab] = useState<string>('tab-badges')
+  const [showAvatarPopup, setShowAvatarPopup] = useState(false)
 
   useEffect(() => {
     const params = new URLSearchParams(location.search)
     const code = params.get('code')
     if (code) setActiveTab('tab-discord')
+    const avatarIntro = params.get('avatarIntro')
+    if (avatarIntro) {
+      setActiveTab('tab-avatar')
+      setShowAvatarPopup(true)
+    }
   }, [location.search])
 
   const openTabSection = (tabName : string) => {
@@ -208,6 +215,9 @@ const UserSettings : React.FC = () => {
           >
             <Discord />
           </motion.div>
+        ) }
+        { showAvatarPopup && (
+          <AvatarIntroPopup onClose={() => setShowAvatarPopup(false)} />
         ) }
       </motion.div>
     </div>

--- a/src/components/Avatar/AvatarIntroPopup.tsx
+++ b/src/components/Avatar/AvatarIntroPopup.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { X } from 'lucide-react'
+import { Button } from 'components/UI/Button'
+
+interface AvatarIntroPopupProps {
+  onClose: () => void
+}
+
+const AvatarIntroPopup: React.FC<AvatarIntroPopupProps> = ({ onClose }) => {
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 z-[999] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          className="relative bg-gray-900 p-6 rounded-xl border border-blue-500/30 shadow-2xl w-full max-w-md"
+          initial={{ scale: 0.9, y: 20 }}
+          animate={{ scale: 1, y: 0 }}
+          exit={{ scale: 0.9, y: 20 }}
+          transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+        >
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 text-gray-400 hover:text-white"
+          >
+            <X size={20} />
+          </button>
+          <h2 className="text-2xl font-bold text-center mb-4 text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
+            Nouveauté : Avatar 3D
+          </h2>
+          <p className="text-gray-300 text-center mb-6">
+            Crée ton avatar 3D personnalisé pour te représenter dans le jeu !
+          </p>
+          <Button
+            onClick={onClose}
+            className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700"
+          >
+            C'est parti !
+          </Button>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}
+
+export default AvatarIntroPopup

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -32,6 +32,9 @@ export const UserProvider : React.FC<{ children : ReactNode }> = ({ children }) 
   const navigate = useNavigate()
   const [stopRequest, setStopRequest] = useState(false)
   const [loading, setLoading] = useState(true)
+  const [avatarRedirected, setAvatarRedirected] = useState(
+    sessionStorage.getItem('avatarIntroShown') === 'true'
+  )
   const { setServerError } = useError()
   const { setToken } = useAuth()
   const callApi = useApi()
@@ -84,6 +87,14 @@ export const UserProvider : React.FC<{ children : ReactNode }> = ({ children }) 
     localStorage.setItem('token', token)
     if (returnTomHome) navigateTo('/')
   }
+
+  useEffect(() => {
+    if (user && user.rpmUserId && !user.rpmAvatarId && !avatarRedirected) {
+      sessionStorage.setItem('avatarIntroShown', 'true')
+      setAvatarRedirected(true)
+      navigate('/account/settings?avatarIntro=1')
+    }
+  }, [user, avatarRedirected, navigate])
 
   const isAdmin = user?.roleId === 1
 


### PR DESCRIPTION
## Summary
- redirect users without RPM avatar to settings
- show an introductory popup on the avatar tab

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `CI=true npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687671744620832389e382a2639c4892